### PR TITLE
Updating smoltcp dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,11 @@ synopsys-usb-otg = { version = "^0.2.4", features = ["cortex-m"], optional = tru
 embedded-display-controller = { version = "^0.1.0", optional = true }
 
 [dependencies.smoltcp]
-version = "0.7.0"
+git = "https://github.com/smoltcp-rs/smoltcp"
+branch = "master"
+# version = "0.7.0"
 default-features = false
-features = ["ethernet", "proto-ipv4", "socket-raw"]
+features = ["medium-ethernet", "proto-ipv4", "socket-raw"]
 optional = true
 
 [dependencies.chrono]
@@ -67,9 +69,11 @@ usb-device = "0.2.5"
 usbd-serial = "0.1.0"
 
 [dev-dependencies.smoltcp]
-version = "0.7.0"
+git = "https://github.com/smoltcp-rs/smoltcp"
+branch = "master"
+# version = "0.7.0"
 default-features = false
-features = ["ethernet", "proto-ipv4", "proto-ipv6", "socket-raw"]
+features = ["medium-ethernet", "proto-ipv4", "proto-ipv6", "socket-raw"]
 
 [features]
 default = ["unproven"]

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -20,7 +20,7 @@ mod utilities;
 use log::info;
 
 use smoltcp::iface::{
-    EthernetInterface, EthernetInterfaceBuilder, Neighbor, NeighborCache,
+    Interface, InterfaceBuilder, Neighbor, NeighborCache,
     Route, Routes,
 };
 use smoltcp::socket::{SocketSet, SocketSetItem};
@@ -74,7 +74,7 @@ static mut STORE: NetStorageStatic = NetStorageStatic {
 };
 
 pub struct Net<'a> {
-    iface: EthernetInterface<'a, ethernet::EthernetDMA<'a>>,
+    iface: Interface<'a, ethernet::EthernetDMA<'a>>,
     sockets: SocketSet<'a>,
 }
 impl<'a> Net<'a> {
@@ -91,7 +91,7 @@ impl<'a> Net<'a> {
             NeighborCache::new(&mut store.neighbor_cache_storage[..]);
         let routes = Routes::new(&mut store.routes_storage[..]);
 
-        let iface = EthernetInterfaceBuilder::new(ethdev)
+        let iface = InterfaceBuilder::new(ethdev)
             .ethernet_addr(ethernet_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs(&mut store.ip_addrs[..])

--- a/examples/ethernet-rtic-stm32h747i-disco.rs
+++ b/examples/ethernet-rtic-stm32h747i-disco.rs
@@ -20,8 +20,7 @@ mod utilities;
 use log::info;
 
 use smoltcp::iface::{
-    Interface, InterfaceBuilder, Neighbor, NeighborCache,
-    Route, Routes,
+    Interface, InterfaceBuilder, Neighbor, NeighborCache, Route, Routes,
 };
 use smoltcp::socket::{SocketSet, SocketSetItem};
 use smoltcp::time::Instant;


### PR DESCRIPTION
This PR updates smoltcp to reference the `smoltcp` master branch.

Note that the smoltcp master branch is tagged as 0.7.0, so if a cargo patch is used instead, the Cargo resolver will override the patch with the published 0.7.4 due to greedy dependency resolution.

Ultimately, I think that smoltcp's master branch should be ahead of 0.7.4 (latest publish), but this is where we're currently at.